### PR TITLE
[work in progress] Node 4 requires gcc-4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ node_js:
   - 4
 # node_js 4 requires gcc 4.8 
 env:
-  - NODE_ENV=travis
-  - CXX="g++-4.8"
+  - NODE_ENV=travis CXX="g++-4.8"
 matrix:
   allow_failures:
     - node_js: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,19 @@ node_js:
   - 4
 env:
   - NODE_ENV=travis
+  - CXX="g++-4.8"
 matrix:
   allow_failures:
     - node_js: 4
 services:
   - mongodb
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - gcc-4.8
 before_install:
   - gem update --system
   - gem install sass --version "=3.3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 0.10
   - 0.12
   - 4
+# node_js 4 requires gcc 4.8 
 env:
   - NODE_ENV=travis
   - CXX="g++-4.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - node_js: 4
 services:
   - mongodb
+# gcc 4.8 requires ubuntu-toolchain-r-test
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "passport-twitter": "^1.0.2",
     "phantomjs": ">=1.9.0",
     "serve-favicon": "^2.3.0",
-    "socket.io": "^1.3.5",
+    "socket.io": "^1.3.7",
     "swig": "^1.4.2",
     "validator": "^3.41.2"
   },


### PR DESCRIPTION
Testing out a change, I was able to get

https://github.com/rla/fast-feed/blob/master/.travis.yml

to work with a similar effort. Node 4 requires gcc-4.8.
